### PR TITLE
add cva (class-variance-authority) to easily manage components variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
+    "class-variance-authority": "^0.6.0",
     "clsx": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,23 +1,37 @@
+import { cva, VariantProps } from 'class-variance-authority';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-type ButtonProps = React.ComponentProps<'button'> & {
-  preset?: 'primary' | 'secondary';
-};
+const buttonStyles = cva(
+  'flex shrink-0 items-center justify-center rounded-md font-medium text-white transition focus:outline-none',
+  {
+    variants: {
+      preset: {
+        primary: 'bg-primary hover:bg-primary/90',
+        secondary: 'bg-secondary hover:bg-secondary/90 rounded-2xl border-gray-800',
+      },
+      size: {
+        small: 'p-1',
+        medium: 'p-2',
+        large: 'p-3',
+      },
+      fullWidth: {
+        true: 'w-full',
+      },
+    },
+    defaultVariants: {
+      preset: 'primary',
+      size: 'medium',
+    },
+  },
+);
 
-const Button = ({ children, className, preset = 'primary', ...props }: ButtonProps) => {
+type ButtonProps = React.ComponentProps<'button'> & VariantProps<typeof buttonStyles>;
+
+const Button = ({ children, className, preset, size, fullWidth, ...props }: ButtonProps) => {
   return (
     <button
-      className={twMerge(
-        clsx(
-          'flex shrink-0 items-center justify-center rounded-md p-2 font-medium text-white transition focus:outline-none',
-          {
-            'bg-primary hover:bg-primary/90': preset === 'primary',
-            'bg-secondary hover:bg-secondary/90': preset === 'secondary',
-          },
-          className,
-        ),
-      )}
+      className={twMerge(clsx(buttonStyles({ preset, size, fullWidth }), className))}
       {...props}
     >
       <span className="truncate">{children}</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3556,6 +3556,13 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+class-variance-authority@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.6.0.tgz#d10df1ee148bb8efc11c17909ef1567abdc85a03"
+  integrity sha512-qdRDgfjx3GRb9fpwpSvn+YaidnT7IUJNe4wt5/SWwM+PmUwJUhQRk/8zAyNro0PmVfmen2635UboTjIBXXxy5A==
+  dependencies:
+    clsx "1.2.1"
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -3625,7 +3632,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.2.1:
+clsx@1.2.1, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==


### PR DESCRIPTION
Minus jest taki, że żeby mieć podpowiedzi klas tailwindowych zgodnie z [dokumentacją](https://cva.style/docs/installation) trzeba dodać takie coś do settings.json (dla vscode).

<img width="1071" alt="image" src="https://github.com/akrolicki/react-boilerplate/assets/62593583/53f52a8e-f92a-4a0c-bdac-258be8f8b3b6">

Natomiast jak już to się doda to póki co innych minusów nie widzę. Pięknie śmiga z typescriptem.
